### PR TITLE
Update to version 2.0.2

### DIFF
--- a/class-yrfw-reviews.php
+++ b/class-yrfw-reviews.php
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || die();
 /**
  * Const definitions
  */
-define( 'YRFW_PLUGIN_VERSION', '2.0.1' );
+define( 'YRFW_PLUGIN_VERSION', '2.0.2' );
 define( 'YRFW_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'YRFW_PLUGIN_URL', plugins_url( '', __FILE__ ) );
 define( 'YRFW_BASENAME', plugin_basename( __FILE__ ) );

--- a/class-yrfw-reviews.php
+++ b/class-yrfw-reviews.php
@@ -136,7 +136,7 @@ class YRFW_Reviews {
 			$this->init();
 		} else {
 			new YRFW_Messages(
-				/* translators: 1:current WC version 2:current PHP version 3:required WC version 4:required∂ PHP version */
+				/* translators: 1:current WC version 2:current PHP version 3:required WC version 4:required PHP version */
 				sprintf( __( '<strong>Yotpo Reviews for WooCommerce -</strong> You are using WooCommerce %1$s and PHP %2$s. <strong>WooCommerce %3$s and above with PHP %4$s and above are required.</strong>', 'yrfw' ), WOOCOMMERCE_VERSION, phpversion(), YRFW_WC_VERSION, YRFW_PHP_VERSION ),
 				'error',
 				false,

--- a/class-yrfw-reviews.php
+++ b/class-yrfw-reviews.php
@@ -4,11 +4,11 @@
 	Plugin Name: Yotpo Reviews for WooCommerce
 	Description: Yotpo Social Reviews helps Woocommerce store owners generate a ton of reviews for their products. Yotpo is the only solution which makes it easy to share your reviews automatically to your social networks to gain a boost in traffic and an increase in sales.
 	Author: Paul Glushak (hxii)
-	Version: 2.0.1
+	Version: 2.0.2
 	Author URI: https://github.com/hxii/
 	Plugin URI: https://github.com/hxii/YRFW
 	WC requires at least: 3.1.0
-	WC tested up to: 3.7.0
+	WC tested up to: 3.9.0
 	Text Domain: yrfw
 	Domain Path: /languages
 

--- a/inc/Base/class-yrfw-assets.php
+++ b/inc/Base/class-yrfw-assets.php
@@ -22,9 +22,9 @@ class YRFW_Assets {
 	private function load_assets() {
 		global $settings_instance;
 		if ( ! is_admin() && true === $settings_instance['authenticated'] ) {
-			add_action( 'wp_enqueue_scripts', array( $this, 'assets_load_frontend' ), 5 );
+			add_action( 'wp_enqueue_scripts', array( $this, 'assets_load_frontend' ), 1 );
 		} else {
-			add_action( 'admin_enqueue_scripts', array( $this, 'assets_load_admin' ), 5 );
+			add_action( 'admin_enqueue_scripts', array( $this, 'assets_load_admin' ), 1 );
 		}
 	}
 
@@ -55,7 +55,7 @@ class YRFW_Assets {
 		add_action( 'wp_head', array( $this, 'assets_preload_js' ), 2 );
 		wp_enqueue_script( 'yotpo_widget', '//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.js', '', null );
 		wp_enqueue_style( 'bottomline_css', ( YRFW_PLUGIN_URL . '/assets/css/bottom-line.css' ) );
-		add_filter( 'script_loader_tag', array( $this, 'append_async' ), 10, 2 );
+		add_filter( 'script_loader_tag', array( $this, 'append_async' ), 1, 2 );
 	}
 
 	/**
@@ -66,11 +66,9 @@ class YRFW_Assets {
 	public function assets_preload_js() {
 		global $settings_instance;
 		$version = $this->get_widget_version();
-		if ( ! is_checkout() ) {
-			echo '<link rel="preload" href="//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.js" as="script">';
-			echo '<link rel="preload" href="//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.css?widget_version=' . $version . '" as="style">';
-			echo '<link rel="preload" href="//staticw2.yotpo.com/assets/yotpo-widget-font.woff?version=' . $version . '" as="font" crossorigin="anonymous">';
-		}
+		echo '<link rel="preload" href="//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.js" as="script">';
+		echo '<link rel="preload" href="//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.css?widget_version=' . $version . '" as="style">';
+		echo '<link rel="preload" href="//staticw2.yotpo.com/assets/yotpo-widget-font.woff?version=' . $version . '" as="font" crossorigin="anonymous">';
 	}
 
 	/**
@@ -85,15 +83,15 @@ class YRFW_Assets {
 	}
 
 	/**
-	 * Append async attribute to Yotpo Widget
+	 * Append defer attribute to Yotpo Widget in order to fix conversion tracking not working.
 	 *
 	 * @param string tag    $tag script tag.
 	 * @param string handle $handle enqueue handle. We're only looking for 'yotpo_widget'.
 	 * @return string filtered tag if handle matches.
 	 */
 	public function append_async( $tag, $handle ) {
-		if ( 'yotpo_widget' === $handle ) {
-			return str_replace( ' src', ' async="async" src', $tag );
+		if ( 'yotpo_widget' === $handle && is_checkout() ) {
+			return str_replace( ' src', ' defer src', $tag );
 		} else {
 			return $tag;
 		}

--- a/inc/Base/class-yrfw-assets.php
+++ b/inc/Base/class-yrfw-assets.php
@@ -35,7 +35,7 @@ class YRFW_Assets {
 	 * @return void
 	 */
 	public function assets_load_admin( $hook ) {
-		if ( strpos( $hook, 'yotpo-reviews') !== false ) {
+		if ( strpos( $hook, 'yotpo-reviews' ) !== false ) {
 			wp_enqueue_style( 'hxii-log-stylesheet', ( YRFW_PLUGIN_URL . '/assets/css/hxii-log.css' ) );
 			wp_enqueue_style( 'bootstrap_css', ( YRFW_PLUGIN_URL . '/assets/css/bootstrap-wrapper.css' ) );
 			wp_enqueue_script( 'yotpoSettingsJs', ( YRFW_PLUGIN_URL . '/assets/js/settings.js' ) );
@@ -51,7 +51,7 @@ class YRFW_Assets {
 	 */
 	public function assets_load_frontend() {
 		global $settings_instance;
-		add_action( 'wp_head', array( $this, 'assets_prefetch_yotpo' ), 1 );
+		add_action( 'wp_head', array( $this, 'assets_preconnect_yotpo' ), 1 );
 		add_action( 'wp_head', array( $this, 'assets_preload_js' ), 2 );
 		wp_enqueue_script( 'yotpo_widget', '//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.js', '', null );
 		wp_enqueue_style( 'bottomline_css', ( YRFW_PLUGIN_URL . '/assets/css/bottom-line.css' ) );
@@ -66,17 +66,19 @@ class YRFW_Assets {
 	public function assets_preload_js() {
 		global $settings_instance;
 		$version = $this->get_widget_version();
-		echo '<link rel="preload" href="//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.js" as="script">';
-		echo '<link rel="preload" href="//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.css?widget_version=' . $version . '" as="style">';
-		echo '<link rel="preload" href="//staticw2.yotpo.com/assets/yotpo-widget-font.woff?version=' . $version . '" as="font" crossorigin="anonymous">';
+		if ( ! is_checkout() ) {
+			echo '<link rel="preload" href="//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.js" as="script">';
+			echo '<link rel="preload" href="//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.css?widget_version=' . $version . '" as="style">';
+			echo '<link rel="preload" href="//staticw2.yotpo.com/assets/yotpo-widget-font.woff?version=' . $version . '" as="font" crossorigin="anonymous">';
+		}
 	}
 
 	/**
-	 * Prefetch for all Yotpo domains
+	 * Preconnect for all Yotpo domains
 	 *
 	 * @return void
 	 */
-	public function assets_prefetch_yotpo() {
+	public function assets_preconnect_yotpo() {
 		echo '<link rel="preconnect" href="//staticw2.yotpo.com">';
 		echo '<link rel="preconnect" href="//api.yotpo.com">';
 		echo '<link rel="preconnect" href="//w2.yotpo.com">';

--- a/inc/Base/class-yrfw-assets.php
+++ b/inc/Base/class-yrfw-assets.php
@@ -55,6 +55,7 @@ class YRFW_Assets {
 		add_action( 'wp_head', array( $this, 'assets_preload_js' ), 2 );
 		wp_enqueue_script( 'yotpo_widget', '//staticw2.yotpo.com/' . $settings_instance['app_key'] . '/widget.js', '', null );
 		wp_enqueue_style( 'bottomline_css', ( YRFW_PLUGIN_URL . '/assets/css/bottom-line.css' ) );
+		add_filter( 'script_loader_tag', array( $this, 'append_async' ), 10, 2 );
 	}
 
 	/**
@@ -77,9 +78,23 @@ class YRFW_Assets {
 	 */
 	public function assets_prefetch_yotpo() {
 		echo '<link rel="preconnect" href="//staticw2.yotpo.com">';
-		echo '<link rel="preconnect" href="//staticw2.yotpo.com/batch">';
 		echo '<link rel="preconnect" href="//api.yotpo.com">';
 		echo '<link rel="preconnect" href="//w2.yotpo.com">';
+	}
+
+	/**
+	 * Append async attribute to Yotpo Widget
+	 *
+	 * @param string tag    $tag script tag.
+	 * @param string handle $handle enqueue handle. We're only looking for 'yotpo_widget'.
+	 * @return string filtered tag if handle matches.
+	 */
+	public function append_async( $tag, $handle ) {
+		if ( 'yotpo_widget' === $handle ) {
+			return str_replace( ' src', ' async="async" src', $tag );
+		} else {
+			return $tag;
+		}
 	}
 
 	/**

--- a/inc/Helpers/class-yrfw-product-cache.php
+++ b/inc/Helpers/class-yrfw-product-cache.php
@@ -65,11 +65,11 @@ class YRFW_Product_Cache {
 	 */
 	public function create_missing_product( int $product_id ) {
 		global $yotpo_products;
-		$missing_product[ $product_id ]          = $yotpo_products->get_product_data( wc_get_product( $product_id ) );
-		$missing_product[ $product_id ]['image'] = $yotpo_products->get_product_image( $product_id );
-		$this->product_cache                     = $missing_product + $this->product_cache;
+		$missing_product                    = $yotpo_products->get_product_data( wc_get_product( $product_id ) );
+		$missing_product['image']           = $yotpo_products->get_product_image( $product_id );
+		$this->product_cache[ $product_id ] = $missing_product;
 		if ( $this->save_products( $this->product_cache ) ) {
-			return $missing_product[ $product_id ];
+			return $missing_product;
 		}
 	}
 
@@ -93,7 +93,7 @@ class YRFW_Product_Cache {
 	public function save_products( $data, string $mode = 'w' ) {
 		$products                       = $data;
 		$products['cache_generated_at'] = date( 'd-m-Y h:i:s' );
-		$products                       = wp_json_encode( $products, JSON_PRETTY_PRINT );
+		$products                       = wp_json_encode( $products );
 		$filesave                       = file_put_contents( $this->filename, $products );
 		if ( false !== $filesave || -1 !== $filesave ) {
 			return true;

--- a/inc/Orders/class-yrfw-products.php
+++ b/inc/Orders/class-yrfw-products.php
@@ -27,10 +27,8 @@ class YRFW_Products {
 				'id'          => ( $id = $product->get_id() ),
 				'url'         => get_permalink( $id ),
 				'lang'        => $settings_instance['yotpo_language_as_site'] ? explode( '-', get_bloginfo( 'language' ) )[0] : $settings_instance['language_code'],
-				// 'description' => wp_strip_all_tags( substr( $product->get_short_description(), 0, 255 ) ),
 				'description' => '',
 				'name'        => $product->get_title(),
-				// 'image'       => $this->get_product_image( $id ),
 				'price'       => $product->get_price(),
 				'specs'       => array_filter( [
 					'external_sku' => $product->get_sku(),

--- a/pages/template-debug.php
+++ b/pages/template-debug.php
@@ -1,5 +1,4 @@
 <?php
-// $settingss = (YRFW_Settings_File::get_instance())->migrate_settings();
 
 global $yotpo_settings, $settings_instance, $yotpo_orders;
 $settings = ( YRFW_Settings_File::get_instance() )->get_settings();

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,7 @@ Just place them in the `/extensions` folder.
 
 == Changelog ==
 = 2.0.2 =
-- Added `async` attribute to Yotpo Widget via function since WP doesn't have that. Conversion doesn't work otherwise.
+- Added `defer` attribute to Yotpo Widget via function since WP doesn't have that. Conversion doesn't work otherwise.
 - Minor changes to how the product cache is appended. Thanks Eric for that `Unsupported operand types`. ¯\_(ツ)_/¯
 - Some cleanup. We don't like messy code.
 - Tested with WP 5.4-alpha-47039 and WC 3.9.0-rc.2. Bleeding edge!

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hxii
 Tags: yotpo,reviews,woocommerce,yrfw
 Donate link: http://paulglushak.com/
 Requires at least: 5.0
-Tested up to: 5.2.3
+Tested up to: 5.4
 Requires PHP: 7.2
 Stable tag: trunk
 License: GPL-3
@@ -42,6 +42,11 @@ You can find some extensions made by me on GitHub [here](https://github.com/hxii
 Just place them in the `/extensions` folder.
 
 == Changelog ==
+= 2.0.2 =
+- Added `async` attribute to Yotpo Widget via function since WP doesn't have that. Conversion doesn't work otherwise.
+- Minor changes to how the product cache is appended. Thanks Eric for that `Unsupported operand types`. ¯\_(ツ)_/¯
+- Some cleanup. We don't like messy code.
+- Tested with WP 5.4-alpha-47039 and WC 3.9.0-rc.2. Bleeding edge!
 = 2.0.1 =
 - Added support for extenstions, see https://github.com/hxii/YRFW-Extensions for examples.
 - Certain things now became extensions (dashboard, debug page, catalog export, rich snippets).


### PR DESCRIPTION
- Added `defer` attribute to Yotpo Widget via function since WP doesn't have that. Conversion doesn't work otherwise.
- Minor changes to how the product cache is appended. Thanks Eric for that `Unsupported operand types`. ¯\\\_(ツ)_/¯
- Some cleanup. We don't like messy code.
- Tested with WP 5.4-alpha-47039 and WC 3.9.0-rc.2. Bleeding edge!